### PR TITLE
Get a backtrace from a test stuck in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           retention-days: 1
 
   build-misc:
+    timeout-minutes: 60
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -40,6 +41,9 @@ jobs:
           - name: macos
             os: macos-latest
     steps:
+      - name: Install gdb
+        if: ${{ matrix.name != 'macos' }}
+        run: sudo apt-get -y install gdb
       - name: Checkout
         uses: actions/checkout@v2
       - name: configure tree
@@ -58,9 +62,18 @@ jobs:
           OCAMLRUNPARAM: v=0,V=1
           USE_RUNTIME: d
         run: |
+          bash -xe tools/ci/actions/backtrace_extractor.sh &
           bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" "lib-threads" "lib-systhreads"
+      - name: Upload backtrace
+        if: cancelled()
+        uses: actions/upload-artifact@v2
+        with:
+          name: last_backtrace ${{ matrix.name }}
+          path: /tmp/last_backtrace.txt
+          retention-days: 1
 
   testsuite:
+    timeout-minutes: 60
     needs: build
     # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds    strategy:
     runs-on: ubuntu-latest
@@ -72,6 +85,9 @@ jobs:
           - normal
           - super
     steps:
+      - name: Install gdb
+        if: ${{ matrix.name != 'macos' }}
+        run: sudo apt-get -y install gdb
       - uses: actions/download-artifact@v2
         with:
           name: compiler
@@ -85,6 +101,7 @@ jobs:
       - name: Run the testsuite (Super Charged)
         if: ${{ matrix.id == 'super' }}
         run: |
+          bash -xe tools/ci/actions/backtrace_extractor.sh &
           bash -xe tools/ci/actions/runner.sh test_multicore 3 "parallel" \
           "callback" "gc-roots" "effects" "lib-threads" "lib-systhreads" \
           "weak-ephe-final"
@@ -94,10 +111,20 @@ jobs:
           USE_RUNTIME: d
         if: ${{ matrix.id == 'debug-s4096' }}
         run: |
+          bash -xe tools/ci/actions/backtrace_extractor.sh &
           bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" \
           "effects" "lib-threads" "lib-systhreads" "weak-ephe-final"
       - name: Run the testsuite (taskset -c 0)
         if: ${{ matrix.id == 'taskset' }}
         run: |
+          bash -xe tools/ci/actions/backtrace_extractor.sh &
           bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" \
           "effects" "lib-threads" "lib-systhreads" "weak-ephe-final"
+      - name: Upload backtrace
+        if: cancelled()
+        uses: actions/upload-artifact@v2
+        with:
+          name: last_backtrace ${{ matrix.name }}
+          path: /tmp/last_backtrace.txt
+          retention-days: 1
+        

--- a/tools/ci/actions/backtrace_extractor.sh
+++ b/tools/ci/actions/backtrace_extractor.sh
@@ -1,0 +1,6 @@
+#!/bin/env bash
+
+while true; do
+    ps -e -o "%p," -o "%a" | grep ocaml | grep -v grep | awk -F , '{ system("date +\"%T\" >> /tmp/last_backtrace.txt; echo \""$2"\" >> /tmp/last_backtrace.txt; sudo gdb -ex \"source tools/ci/actions/gdb_commands\" -batch /proc/"$1"/exe -p "$1" 2> /dev/null")}' >> /tmp/last_backtrace.txt
+    sleep 360
+done

--- a/tools/ci/actions/gdb_commands
+++ b/tools/ci/actions/gdb_commands
@@ -1,0 +1,3 @@
+# gdb commands  to be executedby the backtrace_extractor script.
+set pagination  0
+t a a bt


### PR DESCRIPTION
This branch provides an (hopefully) cherry pickable commit that aims to provide a solution to the extraction of relevant datapoints from a stuck Github Action run.

The way it works is that when running the testsuite, a script (`tools/ci/actions/backtrace_extractor`) will run in the background.
It will attach every 5 minutes to ongoing camel likes processes, and will execute the `gdb` command file at `tools/ci/actions/gdb_commands`.

This file can be embellished to suit your needs.

A new timeout is set on testsuite runs to 60 minutes (well enough to build + run the testsuite in all variants.)
On cancellation (either manually via the Github UI, or via timeout), the `last_backtrace.txt` file is then uploaded as an artifact that can be consulted in the Github Action run breakdown.